### PR TITLE
[CHORE] #27 핀이냐 프로필이냐에 따른 ui변경

### DIFF
--- a/Pinit/Pinit/Views/Home/HomeViewController.swift
+++ b/Pinit/Pinit/Views/Home/HomeViewController.swift
@@ -225,7 +225,7 @@ extension HomeViewController: PinCollectionViewAdapterDelegate {
     func selectedItem(selected: PinEntity) {
         print("Selected: \(selected)")
         // 여기서 화면 이동
-        let vc = PinDetailViewController(selected)
+        let vc = PinDetailViewController(selected, isPin: true)
         vc.sendToBack = {[weak self] entity in
             guard let entity else { return }
             let annotation = CustomAnnotation(pinData: entity)

--- a/Pinit/Pinit/Views/PinDetail/NewPinReviewPanel.swift
+++ b/Pinit/Pinit/Views/PinDetail/NewPinReviewPanel.swift
@@ -46,7 +46,7 @@ class NewPinReviewPanel: UIView {
         textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
         textField.leftViewMode = .always
         
-        textField.placeholder = "리뷰 내용을 입력해주세요"
+        textField.placeholder = "내용을 입력해주세요"
         return textField
     }()
     

--- a/Pinit/Pinit/Views/PinDetail/PinDetailHeader.swift
+++ b/Pinit/Pinit/Views/PinDetail/PinDetailHeader.swift
@@ -8,10 +8,13 @@
 import UIKit
 
 class PinDetailHeader: UIView {
+    
+    private var entity: PinEntity
 
     // MARK: - init
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(entity: PinEntity) {
+        self.entity = entity
+        super.init(frame: .zero)
         addComponents()
     }
     
@@ -23,32 +26,33 @@ class PinDetailHeader: UIView {
     // MARK: - 컴포넌트
     
     // 핀 상세 뷰 컨테이너
-    public lazy var pinDetailPanel: UIView = {
+    private lazy var pinDetailPanel: UIView = {
         let view = UIView()
+
         view.backgroundColor = .white
         return view
     }()
     
     // 핀 제목
-    public lazy var pinTitle: UILabel = {
+    private lazy var pinTitle: UILabel = {
         let label = UILabel()
-        label.text = "핀 제목 예시"
+        label.text = entity.title
         label.font = DesignSystemFont.Pretendard_Bold30.value
         label.numberOfLines = 0
         return label
     }()
     
-    public lazy var pinWeather: UIImageView = {
+    private lazy var pinWeather: UIImageView = {
         let view = UIImageView()
-        view.image = UIImage(named: "clear-day")
+        view.image = UIImage(named: entity.weather)
         view.contentMode = .scaleAspectFit
         return view
     }()
     
     // 핀 생성 날짜
-    public lazy var pinDate: UILabel = {
+    private lazy var pinDate: UILabel = {
         let label = UILabel()
-        label.text = "2021년 1월 1일"
+        label.text = entity.date.koreanDateString()
         label.textColor = .gray
         return label
     }()
@@ -62,26 +66,26 @@ class PinDetailHeader: UIView {
     }()
     
     // 핀 사진
-    public lazy var pinImageView: UIImageView = {
+    private lazy var pinImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(named: "sampleImg.jpg")
+        imageView.image = entity.mediaPath
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
     
     // 핀 추가 설명
-    public lazy var pinDescription: UITextView = {
+    private lazy var pinDescription: UITextView = {
         let textView = UITextView()
-        textView.text = "San Francisco is a city in California. San Francisco is a city in California. San Francisco is a city in California."
+        textView.text = entity.description
         textView.font = DesignSystemFont.Pretendard_Medium16.value
         textView.isScrollEnabled = false // 내부 텍스트가 길어질 때 자동으로 늘어나도록 설정
         textView.sizeToFit()
         return textView
     }()
     
-    public lazy var reviewSectionTitle: UILabel = {
+    private lazy var reviewSectionTitle: UILabel = {
        let label = UILabel()
-        label.text = "Reviews"
+        label.text = entity.address == "" ? "방명록" : "리뷰"
         label.font = DesignSystemFont.Pretendard_Bold20.value
         return label
     }()
@@ -134,16 +138,26 @@ class PinDetailHeader: UIView {
             
             $0.centerX.equalToSuperview()
             $0.width.equalTo(250)
-            $0.height.equalTo(160)
+            
+            if pinImageView.image == nil {
+                $0.height.equalTo(0)
+            } else {
+                $0.height.equalTo(160)
+            }
         }
+        
         
         pinDescription.snp.makeConstraints {
             $0.top.equalTo(pinImageView.snp.bottom).offset(20)
             $0.leading.trailing.equalToSuperview().inset(20)
+            
+            if pinDescription.text == nil || pinDescription.text == "" {
+                $0.height.equalTo(0)
+            }
         }
         
         reviewSectionTitle.snp.makeConstraints {
-            $0.top.equalTo(pinDescription.snp.bottom).offset(10)
+            $0.top.equalTo(pinDescription.snp.bottom).offset(30)
             $0.leading.equalToSuperview().offset(10)
             
         }
@@ -151,9 +165,9 @@ class PinDetailHeader: UIView {
 }
 
 #Preview {
-    PinDetailHeader()
+    PinDetailHeader(entity: PinEntity.sampleData[0])
 }
 
 #Preview {
-    PinDetailViewController(PinEntity.sampleData[0])
+    PinDetailViewController(PinEntity.producerData[1], isPin: true)
 }

--- a/Pinit/Pinit/Views/PinDetail/PinDetailView.swift
+++ b/Pinit/Pinit/Views/PinDetail/PinDetailView.swift
@@ -107,5 +107,5 @@ class PinDetailView: UIView {
 
 
 #Preview {
-    PinDetailViewController(PinEntity.sampleData[0])
+    PinDetailViewController(PinEntity.sampleData[0], isPin: true)
 }

--- a/Pinit/Pinit/Views/PinDetail/PinDetailViewController.swift
+++ b/Pinit/Pinit/Views/PinDetail/PinDetailViewController.swift
@@ -16,12 +16,13 @@ final class PinDetailViewController: UIViewController {
     
     private var pinTableView = UITableView(frame: .zero, style: .grouped)
     private var pinEntity: PinEntity
+    private var isPin: Bool
     private var useCase = DIContainer.usecase
     var sendToBack: ((PinEntity?) -> Void)!
     
-    init(_ entity: PinEntity) {
+    init(_ entity: PinEntity, isPin: Bool) {
         self.pinEntity = entity
-        
+        self.isPin = isPin
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -237,12 +238,8 @@ extension PinDetailViewController: UITableViewDataSource, UITableViewDelegate {
     
     // viewForHeaderInSection
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = PinDetailHeader()
-        header.pinDate.text = pinEntity.date.koreanDateString()
-        header.pinTitle.text = pinEntity.title
-        header.pinImageView.image = pinEntity.mediaPath
-        header.pinWeather.image = UIImage(named: pinEntity.weather)
-        header.pinDescription.text = pinEntity.description
+        let header = PinDetailHeader(entity: pinEntity)
+        if !isPin { header.pinMenuButton.isHidden = true }
         header.pinMenuButton.addTarget(self, action: #selector(pinMenuButtonTapped), for: .touchUpInside)
         return header
     }
@@ -266,5 +263,5 @@ extension PinDetailViewController: UITableViewDataSource, UITableViewDelegate {
 
 
 #Preview {
-    PinDetailViewController(PinEntity.sampleData[0])
+    PinDetailViewController(PinEntity.sampleData[1], isPin: true)
 }

--- a/Pinit/Pinit/Views/Setting/SettingViewController.swift
+++ b/Pinit/Pinit/Views/Setting/SettingViewController.swift
@@ -81,7 +81,7 @@ final class SettingViewController: UIViewController {
 extension SettingViewController : UICollectionViewDelegate, UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let detailVC = PinDetailViewController(PinEntity.producerData[indexPath.row]) //프로필 누르면 상세 화면으로
+        let detailVC = PinDetailViewController(PinEntity.producerData[indexPath.row], isPin: false) //프로필 누르면 상세 화면으로
         
         present(detailVC, animated: true ,completion: nil )
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

Close #27 

## 📝작업 내용

- 받은 엔티티가 핀인지 프로필인지에 따라 핀 메뉴 버튼 비활성화
- 사진과 상세설명이 nil일때는 대비한 레이아웃 작성

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
