### PR TITLE
[FIX] #35 핀상세뷰 키보드 이슈해결, 핀편집-상세뷰 데이터 전달 수정

### DIFF
--- a/Pinit/Pinit/Views/PinDetail/NewPinReviewPanel.swift
+++ b/Pinit/Pinit/Views/PinDetail/NewPinReviewPanel.swift
@@ -45,7 +45,9 @@ class NewPinReviewPanel: UIView {
             .value
         textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
         textField.leftViewMode = .always
-        
+        textField.autocorrectionType = .no
+        textField.autocapitalizationType = .none
+        textField.spellCheckingType = .no
         textField.placeholder = "내용을 입력해주세요"
         return textField
     }()
@@ -55,21 +57,13 @@ class NewPinReviewPanel: UIView {
         let largeConfig = UIImage.SymbolConfiguration(pointSize: 30, weight: .bold, scale: .default)
         let largeImage = UIImage(systemName: "arrow.right.circle.fill")?.withConfiguration(largeConfig)
         button.setImage(largeImage, for: .normal)
-        button.tintColor = .systemGreen
+        button.tintColor = DesignSystemColor.Lavender.value
         return button
     }()
     
-    public lazy var topBorder: UIView = {
-        let border = UIView()
-        border.backgroundColor = .systemGray4
-        return border
-    }()
-    
-    
-    
     private func addComponents() {
         self.addSubviews(newReviewPanel)
-        newReviewPanel.addSubviews(topBorder, reviewDate, reviewText, commitButton)
+        newReviewPanel.addSubviews(reviewDate, reviewText, commitButton)
         
         
         newReviewPanel.snp.makeConstraints {
@@ -85,10 +79,11 @@ class NewPinReviewPanel: UIView {
         
         reviewText.snp.makeConstraints {
             $0.top.equalTo(reviewDate.snp.bottom).offset(10)
-            $0.width.equalTo(340)
+//            $0.width.equalTo(340)
             $0.height.equalTo(40)
             
             $0.leading.equalToSuperview().offset(10)
+            $0.trailing.equalTo(commitButton.snp.leading).offset(-10)
             
         }
         
@@ -104,4 +99,8 @@ class NewPinReviewPanel: UIView {
 
 #Preview {
     NewPinReviewPanel()
+}
+
+#Preview {
+    PinDetailViewController(PinEntity.sampleData[0], isPin: true)
 }

--- a/Pinit/Pinit/Views/PinDetail/PinDetailViewController.swift
+++ b/Pinit/Pinit/Views/PinDetail/PinDetailViewController.swift
@@ -48,10 +48,21 @@ final class PinDetailViewController: UIViewController {
         setupReviewTable()
         addComponents()
         loadReviewData()
+        setUpKeyboard()
         
         reviewPanelContainer.commitButton.addTarget(self, action: #selector(onCommitButtonTapped), for: .touchUpInside)
     }
     
+    private func setUpKeyboard() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillShow),
+                                               name: UIResponder.keyboardWillShowNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillHide),
+                                               name: UIResponder.keyboardWillHideNotification,
+                                               object: nil)
+    }
     
     private func loadReviewData() {
         self.useCase.fetchAllReviewsByPinID(pinID: self.pinEntity.pin_id) {[weak self] items in
@@ -67,7 +78,7 @@ final class PinDetailViewController: UIViewController {
         let lat = pinEntity.latitude
         let long = pinEntity.longitude
         
-        let center = CLLocationCoordinate2D(latitude: lat, longitude: long) // San Francisco, CA
+        let center = CLLocationCoordinate2D(latitude: lat, longitude: long)
         let region = MKCoordinateRegion(center: center, span: MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005))
         
         map.setRegion(region, animated: true)
@@ -75,7 +86,7 @@ final class PinDetailViewController: UIViewController {
         map.isUserInteractionEnabled = false
         
         let annotation = MKPointAnnotation()
-        annotation.coordinate = CLLocationCoordinate2D(latitude: lat, longitude: long) // San Francisco, CA
+        annotation.coordinate = CLLocationCoordinate2D(latitude: lat, longitude: long)
         annotation.title = pinEntity.title
         map.addAnnotation(annotation)
         
@@ -175,6 +186,20 @@ extension PinDetailViewController {
         self.pinTableView.reloadData()
     }
     
+    @objc func doneBtnClicked() {
+        view.endEditing(true)
+    }
+    
+    //MARK: 키보드가 나타낼때 화면을 -300
+    @objc func keyboardWillShow(notification: NSNotification) {
+        view.frame.origin.y = -200
+    }
+    
+    //MARK: 키보드가 사라질 때 동작
+    @objc func keyboardWillHide(notification: NSNotification) {
+        view.frame.origin.y = 0
+    }
+    
     @objc func pinMenuButtonTapped() {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
@@ -185,7 +210,7 @@ extension PinDetailViewController {
                 self.useCase.updatePin(pin: pin)
                 self.updatePinNoti!(self.pinEntity, pin)
                 self.pinEntity = pin
-                #warning("업데이트 후 헤더 업데이트 해줘야함ㅇㅇ")
+                self.pinTableView.reloadData()
             }
             vc.modalPresentationStyle = .fullScreen
             self.present(vc, animated: true, completion: nil)
@@ -215,6 +240,33 @@ extension PinDetailViewController {
 
 // MARK: - Delegate
 extension PinDetailViewController: UITableViewDataSource, UITableViewDelegate {
+    
+    // viewForHeaderInSection
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let header = PinDetailHeader(entity: pinEntity)
+        if !isPin {
+            header.pinMenuButton.isHidden = true
+            header.reviewSectionTitle.text = "방명록"
+        }
+        header.pinMenuButton.addTarget(self, action: #selector(pinMenuButtonTapped), for: .touchUpInside)
+        return header
+    }
+    
+    
+    
+    // estimatedHeightForHeaderInSection
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return 100
+    }
+    
+    // heightForHeaderInSection
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 70
+    }
     
     // didSelectRowAt
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -252,32 +304,7 @@ extension PinDetailViewController: UITableViewDataSource, UITableViewDelegate {
         
     }
     
-    // viewForHeaderInSection
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = PinDetailHeader(entity: pinEntity)
-        if !isPin {
-            header.pinMenuButton.isHidden = true
-            header.reviewSectionTitle.text = "방명록"
-        }
-        header.pinMenuButton.addTarget(self, action: #selector(pinMenuButtonTapped), for: .touchUpInside)
-        return header
-    }
     
-    
-    
-    // estimatedHeightForHeaderInSection
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return 100
-    }
-    
-    // heightForHeaderInSection
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
-    }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 70
-    }
 }
 
 

--- a/Pinit/Pinit/Views/PinEdit/PinEditViewController.swift
+++ b/Pinit/Pinit/Views/PinEdit/PinEditViewController.swift
@@ -17,11 +17,11 @@ enum PinMode {
 
 
 final class PinEditViewController: UIViewController, UITextViewDelegate {
-    private var pinEntity: PinEntity
+    private var pinEntity: PinEntity!
     var isAdded: ((PinEntity) -> Void)? // 핀추가가 됐을때 호출되는 클로저 (홈에서만 사용)
     private var pickedImage: UIImage?
     
-    private var mapView: MKMapView
+    private var mapView: MKMapView!
     
     private let saveButton : UIButton = {
         let button = UIButton()
@@ -41,6 +41,9 @@ final class PinEditViewController: UIViewController, UITextViewDelegate {
         textview.textAlignment = .center
         textview.textColor = UIColor.black
         textview.font = UIFont.systemFont(ofSize: 16)
+        textview.autocorrectionType = .no
+        textview.autocapitalizationType = .none
+        textview.spellCheckingType = .no
         return textview
     }()
     
@@ -58,6 +61,9 @@ final class PinEditViewController: UIViewController, UITextViewDelegate {
             .value
         textfield.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 0))
         textfield.leftViewMode = .always
+        textfield.autocorrectionType = .no
+        textfield.autocapitalizationType = .none
+        textfield.spellCheckingType = .no
         return textfield
     }()
     
@@ -117,6 +123,16 @@ final class PinEditViewController: UIViewController, UITextViewDelegate {
         return toolbar
     }()
     
+    private func setImageToCameraButton(image: UIImage?) {
+        guard let image else { return }
+        self.pickedImage = image
+        cameraButton.backgroundColor = .clear
+        cameraButton.setImage(nil, for: .normal)
+        cameraButton.clipsToBounds = true
+        cameraButton.layer.cornerRadius = 75
+        cameraButton.setBackgroundImage(image, for: .normal)
+    }
+    
     // MARK: - viewDidLoad
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -127,9 +143,10 @@ final class PinEditViewController: UIViewController, UITextViewDelegate {
     }
     
     init(pinMode: PinMode) {
+        super.init(nibName: nil, bundle: nil)
+
         switch pinMode {
         case let .create(latitude, longitude):
-            print("\(latitude), \(longitude)")
             self.pinEntity = PinEntity(
                 pin_id: UUID(),
                 title: "",
@@ -142,13 +159,14 @@ final class PinEditViewController: UIViewController, UITextViewDelegate {
             )
             
         case let .edit(PinEntity):
-            print(PinEntity)
             self.pinEntity = PinEntity
-            print("편집 모드입니다")
             dateLabel.text = pinEntity.date.koreanDateString()
             titleTextField.text = pinEntity.title
             contentTextView.text = pinEntity.description
+            self.setImageToCameraButton(image: pinEntity.mediaPath)
         }
+        
+        
         let map = MKMapView()
         let lat = pinEntity.latitude
         let long = pinEntity.longitude
@@ -165,7 +183,6 @@ final class PinEditViewController: UIViewController, UITextViewDelegate {
         
         mapView = map
         
-        super.init(nibName: nil, bundle: nil)
     }
     
     required init?(coder: NSCoder) {
@@ -255,7 +272,6 @@ final class PinEditViewController: UIViewController, UITextViewDelegate {
         
         pinEntity.title = titleTextField.text ?? ""
         pinEntity.description = contentTextView.text ?? ""
-        
         pinEntity.mediaPath = pickedImage
         
         isAdded?(pinEntity)
@@ -314,7 +330,7 @@ final class PinEditViewController: UIViewController, UITextViewDelegate {
     
     //MARK: 키보드가 나타낼때 화면을 -300
     @objc func keyboardWillShow(notification: NSNotification) {
-        view.frame.origin.y = -300
+        view.frame.origin.y = -250
     }
     
     //MARK: 키보드가 사라질 때 동작
@@ -344,19 +360,7 @@ extension PinEditViewController: UIImagePickerControllerDelegate, UINavigationCo
     
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         if let selectedImage = info[.editedImage] as? UIImage ?? info[.originalImage] as? UIImage {
-            self.pickedImage = selectedImage
-            cameraButton.backgroundColor = .clear
-            cameraButton.setImage(nil, for: .normal)
-            //
-            //            // 이미지를 버튼 크기에 맞게 조정하여 설정
-            //            let resizedImage = resizeImage(image: pickedImage, targetSize: CGSize(width: 150, height: 150))
-            
-            cameraButton.clipsToBounds = true
-            cameraButton.layer.cornerRadius = 75
-            cameraButton.setBackgroundImage(pickedImage, for: .normal)
-            
-            // 선택한 이미지를 pinEntity에 저장 (나중에 경로로 변환하는 로직 추가 필요)
-            // pinEntity?.mediaPath = ...
+            setImageToCameraButton(image: selectedImage)
         }
         picker.dismiss(animated: true, completion: nil)
     }

--- a/Pinit/Pinit/Views/PinEdit/PinEditViewController.swift
+++ b/Pinit/Pinit/Views/PinEdit/PinEditViewController.swift
@@ -215,8 +215,9 @@ final class PinEditViewController: UIViewController, UITextViewDelegate {
         
         weatherImage.snp.makeConstraints{
             $0.top.equalTo(mapView.snp.bottom).offset(10)
-            $0.leading.equalTo(view.snp.centerX).offset(100)
-            $0.height.width.equalTo(30)
+//            $0.leading.equalTo(view.snp.centerX).offset(100)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.height.width.equalTo(35)
         }
         
         dateLabel.snp.makeConstraints{


### PR DESCRIPTION
## #️⃣연관된 이슈

Close #35 

## 📝작업 내용

- 핀상세뷰 키보드 겹쳐지는 이슈해결
- 핀편집-상세뷰 데이터 전달 후 내용 업데이트 구현
- 상세 - 편집 이동시 사진이 전달 안되는 이슈 수정
- 핀 상세뷰 버튼에 하이라이트 컬러 적용
- 핀 상세뷰의 리뷰 텍스트 필드가 작은화면에서 버튼과 겹쳐지는 이슈 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
